### PR TITLE
fix: corrigir nome da coluna timestamp para criado_em em eventos e ig…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ dist/
 build/
 .next/
 .claude/
+.postman/
+postman/

--- a/backend/src/controllers/eventos.controller.js
+++ b/backend/src/controllers/eventos.controller.js
@@ -22,7 +22,7 @@ export async function registrarEvento(req, res) {
 
   const { data, error } = await supabase
     .from('eventos')
-    .insert({ cliente_id, descricao, sucesso, timestamp: new Date().toISOString() })
+    .insert({ cliente_id, descricao, sucesso })
     .select()
     .single();
 


### PR DESCRIPTION
…norar pastas postman

A migration usa criado_em como nome da coluna, não timestamp. Descoberto durante testes no Postman — insert falhava silenciosamente.