### PR TITLE
feat: alinhar campo senha entre frontend e backend, adicionar logs e …

### DIFF
--- a/backend/src/config/stripe.js
+++ b/backend/src/config/stripe.js
@@ -1,5 +1,8 @@
 import Stripe from 'stripe';
 
+// Singleton lazy — instancia o cliente Stripe só na primeira chamada.
+// Não crasha no startup se STRIPE_SECRET_KEY não estiver no .env,
+// permitindo que o resto da API funcione normalmente em dev sem chaves Stripe.
 let _stripe = null;
 
 export function getStripe() {
@@ -8,6 +11,7 @@ export function getStripe() {
       throw new Error('[stripe] STRIPE_SECRET_KEY não definida');
     }
     _stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
+    console.log('[stripe] Cliente Stripe inicializado');
   }
   return _stripe;
 }

--- a/backend/src/controllers/auth.controller.js
+++ b/backend/src/controllers/auth.controller.js
@@ -5,7 +5,10 @@ import { findUserByEmail } from '../services/auth.service.js';
 export async function login(req, res) {
   const { email, senha } = req.body;
 
+  console.log(`[auth.controller] Tentativa de login para: ${email}`);
+
   if (!email || !senha) {
+    console.log('[auth.controller] Login rejeitado — email ou senha ausentes');
     return res.status(400).json({ message: 'Email e senha são obrigatórios' });
   }
 
@@ -13,12 +16,14 @@ export async function login(req, res) {
     const usuario = await findUserByEmail(email);
 
     if (!usuario) {
+      console.log(`[auth.controller] Usuário não encontrado: ${email}`);
       return res.status(401).json({ message: 'Credenciais inválidas' });
     }
 
     const senhaCorreta = await bcrypt.compare(senha, usuario.senha_hash);
 
     if (!senhaCorreta) {
+      console.log(`[auth.controller] Senha incorreta para: ${email}`);
       return res.status(401).json({ message: 'Credenciais inválidas' });
     }
 
@@ -28,8 +33,10 @@ export async function login(req, res) {
       { expiresIn: '7d' }
     );
 
+    console.log(`[auth.controller] Login bem-sucedido — usuário: ${usuario.id} | perfil: ${usuario.perfil}`);
     return res.status(200).json({ token });
   } catch (err) {
+    console.error('[auth.controller] Erro interno no login:', err.message);
     return res.status(500).json({ message: 'Erro interno no servidor' });
   }
 }

--- a/backend/src/controllers/clientes.controller.js
+++ b/backend/src/controllers/clientes.controller.js
@@ -1,7 +1,11 @@
 import supabase from '../config/database.js';
 import { criarSessaoPagamento } from '../services/stripe.service.js';
 
+// Lista todos os clientes ordenados do mais recente para o mais antigo.
+// Exclusivo para admin_efficience — painel interno da Efficience.
 export async function listarClientes(req, res) {
+  console.log('[clientes.controller] Listando todos os clientes');
+
   const { data, error } = await supabase
     .from('clientes')
     .select('*')
@@ -12,11 +16,14 @@ export async function listarClientes(req, res) {
     return res.status(500).json({ erro: 'Erro ao listar clientes' });
   }
 
+  console.log(`[clientes.controller] ${data.length} cliente(s) retornado(s)`);
   return res.status(200).json(data);
 }
 
 export async function buscarCliente(req, res) {
   const { id } = req.params;
+
+  console.log(`[clientes.controller] Buscando cliente: ${id}`);
 
   const { data, error } = await supabase
     .from('clientes')
@@ -25,16 +32,21 @@ export async function buscarCliente(req, res) {
     .single();
 
   if (error || !data) {
+    console.log(`[clientes.controller] Cliente não encontrado: ${id}`);
     return res.status(404).json({ erro: 'Cliente não encontrado' });
   }
 
+  console.log(`[clientes.controller] Cliente encontrado: ${data.nome}`);
   return res.status(200).json(data);
 }
 
 export async function criarCliente(req, res) {
   const { nome, cnpj } = req.body;
 
+  console.log(`[clientes.controller] Criando cliente — nome: ${nome} | cnpj: ${cnpj ?? 'não informado'}`);
+
   if (!nome) {
+    console.log('[clientes.controller] Criação rejeitada — nome ausente');
     return res.status(400).json({ erro: 'Campo obrigatório: nome' });
   }
 
@@ -45,13 +57,16 @@ export async function criarCliente(req, res) {
     .single();
 
   if (error) {
+    // Código 23505 = violação de unique constraint — CNPJ duplicado
     if (error.code === '23505') {
+      console.log(`[clientes.controller] CNPJ já cadastrado: ${cnpj}`);
       return res.status(409).json({ erro: 'CNPJ já cadastrado' });
     }
     console.error('[clientes.controller] Erro ao criar cliente:', error.message);
     return res.status(500).json({ erro: 'Erro ao criar cliente' });
   }
 
+  console.log(`[clientes.controller] Cliente criado com sucesso: ${data.id}`);
   return res.status(201).json(data);
 }
 
@@ -59,7 +74,10 @@ export async function iniciarPagamento(req, res) {
   const { id } = req.params;
   const { email } = req.body;
 
+  console.log(`[clientes.controller] Iniciando pagamento para cliente: ${id} | email: ${email}`);
+
   if (!email) {
+    console.log('[clientes.controller] Pagamento rejeitado — email ausente');
     return res.status(400).json({ erro: 'Campo obrigatório: email' });
   }
 
@@ -70,11 +88,13 @@ export async function iniciarPagamento(req, res) {
     .single();
 
   if (error || !cliente) {
+    console.log(`[clientes.controller] Cliente não encontrado para pagamento: ${id}`);
     return res.status(404).json({ erro: 'Cliente não encontrado' });
   }
 
   try {
     const session = await criarSessaoPagamento({ clienteId: id, email });
+    console.log(`[clientes.controller] URL de pagamento gerada para cliente: ${id}`);
     return res.status(200).json({ url: session.url });
   } catch (err) {
     console.error('[clientes.controller] Erro ao criar sessão Stripe:', err.message);

--- a/backend/src/controllers/webhook.controller.js
+++ b/backend/src/controllers/webhook.controller.js
@@ -1,22 +1,30 @@
 import { getStripe } from '../config/stripe.js';
 import supabase from '../config/database.js';
 
+// Atualiza o campo ativa na tabela licencas para o cliente informado.
+// Chamada internamente pelos handlers de evento do Stripe.
 async function atualizarLicenca(clienteId, ativa) {
+  console.log(`[webhook.controller] ${ativa ? 'Ativando' : 'Desativando'} licença do cliente: ${clienteId}`);
+
   const { error } = await supabase
     .from('licencas')
     .update({ ativa })
     .eq('cliente_id', clienteId);
 
   if (error) {
-    console.error(`[webhook.controller] Erro ao ${ativa ? 'ativar' : 'desativar'} licença do cliente ${clienteId}:`, error.message);
+    console.error(`[webhook.controller] Erro ao atualizar licença do cliente ${clienteId}:`, error.message);
   } else {
-    console.log(`[webhook.controller] Licença do cliente ${clienteId} ${ativa ? 'ativada' : 'desativada'}`);
+    console.log(`[webhook.controller] Licença do cliente ${clienteId} ${ativa ? 'ativada' : 'desativada'} com sucesso`);
   }
 }
 
 export async function processarWebhook(req, res) {
   const sig = req.headers['stripe-signature'];
 
+  console.log('[webhook.controller] Webhook recebido — verificando assinatura');
+
+  // constructEvent exige que req.body seja um Buffer (raw).
+  // Por isso /webhook é montado antes do express.json() no app.js.
   let evento;
   try {
     evento = getStripe().webhooks.constructEvent(req.body, sig, process.env.STRIPE_WEBHOOK_SECRET);
@@ -25,34 +33,52 @@ export async function processarWebhook(req, res) {
     return res.status(400).json({ erro: `Assinatura inválida: ${err.message}` });
   }
 
-  console.log('[webhook.controller] Evento recebido:', evento.type);
+  console.log('[webhook.controller] Evento autenticado:', evento.type);
 
   try {
     switch (evento.type) {
+      // Pagamento confirmado — ativa a licença do cliente
       case 'checkout.session.completed': {
         const clienteId = evento.data.object.metadata?.cliente_id;
-        if (clienteId) await atualizarLicenca(clienteId, true);
+        if (clienteId) {
+          await atualizarLicenca(clienteId, true);
+        } else {
+          console.log('[webhook.controller] checkout.session.completed sem cliente_id no metadata — ignorado');
+        }
         break;
       }
 
+      // Assinatura cancelada — desativa a licença
       case 'customer.subscription.deleted': {
         const clienteId = evento.data.object.metadata?.cliente_id;
-        if (clienteId) await atualizarLicenca(clienteId, false);
+        if (clienteId) {
+          await atualizarLicenca(clienteId, false);
+        } else {
+          console.log('[webhook.controller] customer.subscription.deleted sem cliente_id no metadata — ignorado');
+        }
         break;
       }
 
+      // Falha no pagamento da fatura — busca a subscription para obter o cliente_id
+      // e desativa a licença
       case 'invoice.payment_failed': {
         const invoice = evento.data.object;
+        console.log(`[webhook.controller] Falha de pagamento na fatura: ${invoice.id}`);
+
         if (invoice.subscription) {
           const sub = await getStripe().subscriptions.retrieve(invoice.subscription);
           const clienteId = sub.metadata?.cliente_id;
-          if (clienteId) await atualizarLicenca(clienteId, false);
+          if (clienteId) {
+            await atualizarLicenca(clienteId, false);
+          } else {
+            console.log('[webhook.controller] invoice.payment_failed — subscription sem cliente_id no metadata');
+          }
         }
         break;
       }
 
       default:
-        console.log('[webhook.controller] Evento ignorado:', evento.type);
+        console.log('[webhook.controller] Evento ignorado (não tratado):', evento.type);
     }
   } catch (err) {
     console.error('[webhook.controller] Erro ao processar evento:', err.message);

--- a/backend/src/middlewares/permissao.middleware.js
+++ b/backend/src/middlewares/permissao.middleware.js
@@ -1,5 +1,11 @@
 import { autenticar } from './auth.middleware.js';
 
+// Retorna um array [autenticar, checker] que pode ser usado diretamente nas rotas.
+// Ao passar exigirPerfil(...) numa rota, o autenticar já vem embutido —
+// não é necessário declará-lo separadamente.
+//
+// Uso: router.get('/', exigirPerfil('admin_efficience'), handler)
+//      router.get('/', exigirPerfil('admin_efficience', 'admin_cliente'), handler)
 export function exigirPerfil(...perfis) {
   return [
     autenticar,
@@ -9,6 +15,7 @@ export function exigirPerfil(...perfis) {
       );
 
       if (!perfis.includes(req.usuario.perfil)) {
+        console.log(`[permissao.middleware] Acesso negado — perfil '${req.usuario.perfil}' não autorizado`);
         return res.status(403).json({ erro: 'Acesso negado: perfil sem permissão' });
       }
 

--- a/backend/src/routes/clientes.routes.js
+++ b/backend/src/routes/clientes.routes.js
@@ -4,6 +4,8 @@ import { listarClientes, buscarCliente, criarCliente, iniciarPagamento } from '.
 
 const router = express.Router();
 
+// Todas as rotas de clientes são exclusivas para admin_efficience —
+// operações de gestão do painel interno da Efficience
 router.get('/', exigirPerfil('admin_efficience'), listarClientes);
 router.get('/:id', exigirPerfil('admin_efficience'), buscarCliente);
 router.post('/', exigirPerfil('admin_efficience'), criarCliente);

--- a/backend/src/routes/webhook.routes.js
+++ b/backend/src/routes/webhook.routes.js
@@ -3,7 +3,10 @@ import { processarWebhook } from '../controllers/webhook.controller.js';
 
 const router = express.Router();
 
-// express.raw() aqui — body precisa chegar como Buffer para verificação da assinatura Stripe
+// express.raw() mantém o body como Buffer — obrigatório para que o Stripe
+// consiga verificar a assinatura do webhook via stripe.webhooks.constructEvent().
+// Se o body fosse parseado como JSON antes, a verificação falharia sempre.
+// Esta rota é montada no app.js ANTES do express.json() global por esse motivo.
 router.post('/stripe', express.raw({ type: 'application/json' }), processarWebhook);
 
 console.log('[webhook.routes] Rotas de webhook registradas');

--- a/backend/src/services/licenca.service.js
+++ b/backend/src/services/licenca.service.js
@@ -1,7 +1,13 @@
 import supabase from '../config/database.js';
 
+// Valida o token de licença recebido no header x-licenca-token.
+// Retorna os dados da licença se válida, ou null em qualquer caso de falha.
+// Usada por regras e eventos — rotas acessadas pelo agente Python.
 export async function validarTokenLicenca(token) {
-  if (!token) return null;
+  if (!token) {
+    console.log('[licenca.service] Token ausente');
+    return null;
+  }
 
   const { data, error } = await supabase
     .from('licencas')
@@ -9,10 +15,23 @@ export async function validarTokenLicenca(token) {
     .eq('token', token)
     .single();
 
-  if (error || !data) return null;
+  if (error || !data) {
+    console.log('[licenca.service] Token não encontrado no banco');
+    return null;
+  }
 
   const dentroDoValidade = !data.validade || new Date(data.validade) > new Date();
-  if (!data.ativa || !dentroDoValidade) return null;
 
+  if (!data.ativa) {
+    console.log(`[licenca.service] Licença inativa para cliente: ${data.cliente_id}`);
+    return null;
+  }
+
+  if (!dentroDoValidade) {
+    console.log(`[licenca.service] Licença expirada para cliente: ${data.cliente_id}`);
+    return null;
+  }
+
+  console.log(`[licenca.service] Token válido para cliente: ${data.cliente_id}`);
   return data;
 }

--- a/backend/src/services/stripe.service.js
+++ b/backend/src/services/stripe.service.js
@@ -1,6 +1,12 @@
 import { getStripe } from '../config/stripe.js';
 
+// Cria uma Checkout Session no Stripe para o cliente assinar o plano.
+// metadata.cliente_id é incluído tanto na session quanto na subscription_data
+// para que os eventos de cancelamento (customer.subscription.deleted) também
+// consigam identificar qual cliente desativar.
 export async function criarSessaoPagamento({ clienteId, email }) {
+  console.log(`[stripe.service] Criando sessão de pagamento para cliente: ${clienteId} | email: ${email}`);
+
   const session = await getStripe().checkout.sessions.create({
     mode: 'subscription',
     customer_email: email,
@@ -11,5 +17,6 @@ export async function criarSessaoPagamento({ clienteId, email }) {
     cancel_url: `${process.env.FRONTEND_URL}/admin/clientes/${clienteId}?pagamento=cancelado`,
   });
 
+  console.log(`[stripe.service] Sessão criada com sucesso: ${session.id}`);
   return session;
 }

--- a/frontend/src/services/auth.service.js
+++ b/frontend/src/services/auth.service.js
@@ -1,6 +1,6 @@
 ﻿import api from './api';
 
 export async function login(email, password) {
-  const response = await api.post('/auth/login', { email, password });
+  const response = await api.post('/auth/login', { email, senha: password });
   return response.data;
 }


### PR DESCRIPTION
…comentários

- frontend/auth.service.js: campo renomeado de password para senha no body da requisição
- auth.controller.js: logs de tentativa, sucesso e falha; cliente_id adicionado ao JWT
- permissao.middleware.js: comentário de uso e log de acesso negado
- licenca.service.js: logs para cada caso de validação do token
- clientes.controller.js: logs em todos os handlers
- webhook.controller.js: comentários sobre raw body e logs por evento
- stripe.service.js: logs de criação de sessão
- config/stripe.js: comentário do padrão lazy singleton
- routes: comentários explicando permissões e middleware