### PR TITLE
feat: add JWT interceptor to api.js and create licenca.service.js

### DIFF
--- a/backend/src/controllers/licenca.controller.js
+++ b/backend/src/controllers/licenca.controller.js
@@ -1,5 +1,28 @@
 import supabase from "../config/database.js";
 
+export async function buscarLicencaCliente(req, res) {
+  const { clienteId } = req.params;
+  const { perfil, cliente_id } = req.usuario;
+
+  if (perfil === "admin_cliente" && cliente_id !== clienteId) {
+    return res.status(403).json({ erro: "Acesso negado" });
+  }
+
+  const { data, error } = await supabase
+    .from("licencas")
+    .select("ativa, validade")
+    .eq("cliente_id", clienteId)
+    .single();
+
+  if (error || !data) {
+    return res.status(404).json({ erro: "Licença não encontrada" });
+  }
+
+  const ativa = data.ativa && (!data.validade || new Date(data.validade) > new Date());
+
+  return res.status(200).json({ ativa, validade: data.validade });
+}
+
 export async function validarLicenca(req, res) {
   const token = req.headers["x-licenca-token"];
 

--- a/backend/src/routes/licenca.routes.js
+++ b/backend/src/routes/licenca.routes.js
@@ -1,8 +1,13 @@
 import express from "express";
-import { validarLicenca } from "../controllers/licenca.controller.js";
+import { validarLicenca, buscarLicencaCliente } from "../controllers/licenca.controller.js";
+import { autenticar } from "../middlewares/auth.middleware.js";
 
 const router = express.Router();
 
+// Rota do agente — autenticada via x-licenca-token
 router.get("/validar", validarLicenca);
+
+// Rota do frontend — autenticada via JWT
+router.get("/:clienteId", autenticar, buscarLicencaCliente);
 
 export default router;

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -4,4 +4,12 @@ const api = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_URL,
 });
 
+api.interceptors.request.use((config) => {
+  const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
 export default api;

--- a/frontend/src/services/licenca.service.js
+++ b/frontend/src/services/licenca.service.js
@@ -1,0 +1,6 @@
+import api from './api';
+
+export async function buscarLicenca(clienteId) {
+  const response = await api.get(`/licenca/${clienteId}`);
+  return response.data;
+}


### PR DESCRIPTION
- api.js: request interceptor injects Bearer token from localStorage (SSR-safe via typeof window guard)
- licenca.service.js: buscarLicenca(clienteId) calls GET /licenca/:clienteId
- backend: new buscarLicencaCliente controller with ownership check for admin_cliente
- backend: GET /licenca/:clienteId route protected by JWT; /validar preserved for agent