### PR TITLE
fix: regra sem condicao nao deve mover arquivos

### DIFF
--- a/agente/automacoes/monitorar_pasta.py
+++ b/agente/automacoes/monitorar_pasta.py
@@ -53,9 +53,7 @@ def _arquivo_pertence_origem(caminho, pasta_origem):
     return os.path.dirname(os.path.abspath(caminho)) == os.path.abspath(pasta_origem)
 
 def _bate_condicao(caminho, condicao):
-    if not condicao:
-        return True
-    if condicao.startswith("extensao="):
+    if condicao and condicao.startswith("extensao="):
         ext = condicao.split("=")[1]
         return caminho.endswith(ext)
     return False


### PR DESCRIPTION
Reverte comportamento incorreto onde condicao=None retornava True (movendo qualquer arquivo). Correto: sem condicao -> nao bate -> nao move.