### PR TITLE
fix: torna AUTH_TOKEN opcional no agente para evitar 401 em /licenca/…

### DIFF
--- a/agente/comunicacao/api_client.py
+++ b/agente/comunicacao/api_client.py
@@ -9,14 +9,11 @@ TOKEN = os.getenv('AUTH_TOKEN', '')
 LICENSE_TOKEN = os.getenv('LICENSE_TOKEN')
 CLIENTE_ID = os.getenv('CLIENTE_ID')
 
-if not TOKEN:
-    raise EnvironmentError("AUTH_TOKEN não definido nas variáveis de ambiente")
-
 def _headers(extra=None):
-    headers = {
-        "Authorization": f"Bearer {TOKEN}",
-        "Content-Type": "application/json"
-    }
+    headers = {"Content-Type": "application/json"}
+
+    if TOKEN:
+        headers["Authorization"] = f"Bearer {TOKEN}"
 
     if extra:
         headers.update(extra)


### PR DESCRIPTION
…validar

autenticarOpcional retornava 401 ao receber AUTH_TOKEN inválido como Bearer. Agente autentica via x-licenca-token — JWT nunca foi necessário.