### PR TITLE
feat: implementação de central de notiificações com estado gobal e ba…

### DIFF
--- a/frontend/src/app/comunicacao/page.jsx
+++ b/frontend/src/app/comunicacao/page.jsx
@@ -2,76 +2,23 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import {
+  notificacaoNaoLida,
+  obterDataNotificacao,
+  useNotificacoes,
+} from '../../context/NotificacoesContext';
 import { useAuth } from '../../context/AuthContext';
-import { listarNotificacoes } from '../../services/notificacoes.service';
 
 function obterMensagemErro(error) {
   return (
     error?.response?.data?.erro ||
     error?.response?.data?.message ||
     error?.message ||
-    'Nao foi possivel carregar as notificacoes.'
+    'Nao foi possivel atualizar a notificacao.'
   );
 }
 
-function normalizarNotificacoes(payload) {
-  if (Array.isArray(payload)) {
-    return payload;
-  }
-
-  if (Array.isArray(payload?.data)) {
-    return payload.data;
-  }
-
-  if (Array.isArray(payload?.items)) {
-    return payload.items;
-  }
-
-  if (Array.isArray(payload?.notificacoes)) {
-    return payload.notificacoes;
-  }
-
-  return [];
-}
-
-function notificacaoNaoLida(notificacao) {
-  if (!notificacao) {
-    return false;
-  }
-
-  if (notificacao.nao_lida === true) {
-    return true;
-  }
-
-  if (notificacao.lida === false || notificacao.lido === false || notificacao.read === false) {
-    return true;
-  }
-
-  const status = String(notificacao.status || '').toLowerCase();
-  if (status === 'nao_lida' || status === 'nao lida' || status === 'unread') {
-    return true;
-  }
-
-  return false;
-}
-
-function contarNaoLidas(payload, notificacoes) {
-  if (typeof payload?.nao_lidas === 'number') {
-    return payload.nao_lidas;
-  }
-
-  if (typeof payload?.total_nao_lidas === 'number') {
-    return payload.total_nao_lidas;
-  }
-
-  if (typeof payload?.unread === 'number') {
-    return payload.unread;
-  }
-
-  return notificacoes.filter(notificacaoNaoLida).length;
-}
-
-function tituloNotificacao(notificacao, index) {
+function obterTitulo(notificacao, index) {
   return (
     notificacao?.titulo ||
     notificacao?.assunto ||
@@ -81,13 +28,20 @@ function tituloNotificacao(notificacao, index) {
   );
 }
 
-function dataNotificacao(notificacao) {
-  return (
-    notificacao?.criado_em ||
-    notificacao?.created_at ||
-    notificacao?.data ||
-    notificacao?.timestamp
-  );
+function obterDescricao(notificacao) {
+  if (notificacao?.descricao) {
+    return notificacao.descricao;
+  }
+
+  if (notificacao?.mensagem && notificacao?.mensagem !== notificacao?.titulo) {
+    return notificacao.mensagem;
+  }
+
+  if (notificacao?.detalhe) {
+    return notificacao.detalhe;
+  }
+
+  return '';
 }
 
 function formatarDataHora(data) {
@@ -106,28 +60,82 @@ function formatarDataHora(data) {
   }).format(valor);
 }
 
+function obterTimestamp(notificacao) {
+  const data = obterDataNotificacao(notificacao);
+  const valor = new Date(data || '');
+
+  if (Number.isNaN(valor.getTime())) {
+    return 0;
+  }
+
+  return valor.getTime();
+}
+
+function obterTipoNotificacao(notificacao) {
+  const campos = [
+    notificacao?.tipo,
+    notificacao?.categoria,
+    notificacao?.origem,
+    notificacao?.contexto,
+    notificacao?.titulo,
+    notificacao?.descricao,
+    notificacao?.mensagem,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+
+  if (campos.includes('obrig')) {
+    return {
+      chave: 'obrigacao',
+      label: 'Obrigacao',
+      icon: ObrigacaoIcon,
+      classes: 'bg-indigo-100 text-indigo-700',
+    };
+  }
+
+  if (campos.includes('process')) {
+    return {
+      chave: 'processo',
+      label: 'Processo',
+      icon: ProcessoIcon,
+      classes: 'bg-amber-100 text-amber-700',
+    };
+  }
+
+  if (campos.includes('arquiv') || campos.includes('document')) {
+    return {
+      chave: 'arquivo',
+      label: 'Arquivo',
+      icon: ArquivoIcon,
+      classes: 'bg-emerald-100 text-emerald-700',
+    };
+  }
+
+  return {
+    chave: 'geral',
+    label: 'Geral',
+    icon: GeralIcon,
+    classes: 'bg-slate-100 text-slate-700',
+  };
+}
+
 export default function ComunicacaoPage() {
   const router = useRouter();
   const { isAuthenticated, isLoading } = useAuth();
-  const [payload, setPayload] = useState(null);
-  const [notificacoes, setNotificacoes] = useState([]);
-  const [isLoadingNotificacoes, setIsLoadingNotificacoes] = useState(true);
-  const [erro, setErro] = useState('');
+  const {
+    notificacoes,
+    naoLidas,
+    erro,
+    isLoadingNotificacoes,
+    isAtualizando,
+    carregarNotificacoes,
+    marcarComoLida,
+    marcarTodasComoLidas,
+  } = useNotificacoes();
 
-  const carregarNotificacoes = useCallback(async () => {
-    setIsLoadingNotificacoes(true);
-    setErro('');
-
-    try {
-      const data = await listarNotificacoes();
-      setPayload(data);
-      setNotificacoes(normalizarNotificacoes(data));
-    } catch (error) {
-      setErro(obterMensagemErro(error));
-    } finally {
-      setIsLoadingNotificacoes(false);
-    }
-  }, []);
+  const [erroAcao, setErroAcao] = useState('');
+  const [idAtualizando, setIdAtualizando] = useState(null);
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
@@ -135,16 +143,45 @@ export default function ComunicacaoPage() {
     }
   }, [isAuthenticated, isLoading, router]);
 
-  useEffect(() => {
-    if (!isLoading && isAuthenticated) {
-      carregarNotificacoes();
-    }
-  }, [carregarNotificacoes, isAuthenticated, isLoading]);
-
-  const naoLidas = useMemo(
-    () => contarNaoLidas(payload, notificacoes),
-    [payload, notificacoes],
+  const notificacoesOrdenadas = useMemo(
+    () => [...notificacoes].sort((a, b) => obterTimestamp(b) - obterTimestamp(a)),
+    [notificacoes],
   );
+
+  const totalLidas = useMemo(
+    () => notificacoesOrdenadas.length - naoLidas,
+    [notificacoesOrdenadas.length, naoLidas],
+  );
+
+  const handleMarcarComoLida = useCallback(
+    async (id) => {
+      if (!id) {
+        return;
+      }
+
+      setErroAcao('');
+      setIdAtualizando(id);
+
+      try {
+        await marcarComoLida(id);
+      } catch (error) {
+        setErroAcao(obterMensagemErro(error));
+      } finally {
+        setIdAtualizando(null);
+      }
+    },
+    [marcarComoLida],
+  );
+
+  const handleMarcarTodas = useCallback(async () => {
+    setErroAcao('');
+
+    try {
+      await marcarTodasComoLidas();
+    } catch (error) {
+      setErroAcao(obterMensagemErro(error));
+    }
+  }, [marcarTodasComoLidas]);
 
   if (isLoading) {
     return <p>Carregando...</p>;
@@ -156,27 +193,43 @@ export default function ComunicacaoPage() {
 
   return (
     <main className="space-y-6 p-6">
-      <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <header className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
         <div>
-          <h1 className="text-2xl font-semibold text-zinc-900">Comunicacao</h1>
+          <h1 className="text-2xl font-semibold text-zinc-900">Central de notificacoes</h1>
           <p className="mt-1 text-sm text-zinc-500">
-            Central de notificacoes recebidas pelo cliente.
+            Acompanhe alertas de obrigacoes, processos e arquivos em tempo real.
           </p>
         </div>
 
-        <button
-          type="button"
-          onClick={carregarNotificacoes}
-          disabled={isLoadingNotificacoes}
-          className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          {isLoadingNotificacoes ? 'Atualizando...' : 'Atualizar lista'}
-        </button>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={carregarNotificacoes}
+            disabled={isLoadingNotificacoes}
+            className="rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm font-medium text-zinc-800 transition hover:bg-zinc-50 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isLoadingNotificacoes ? 'Atualizando...' : 'Atualizar lista'}
+          </button>
+          <button
+            type="button"
+            onClick={handleMarcarTodas}
+            disabled={naoLidas === 0 || isAtualizando}
+            className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isAtualizando ? 'Processando...' : 'Marcar todas como lidas'}
+          </button>
+        </div>
       </header>
 
-      <section className="rounded-xl border border-sky-200 bg-sky-50 p-5 shadow-sm">
-        <p className="text-xs font-semibold uppercase tracking-wide text-sky-700">Nao lidas</p>
-        <p className="mt-2 text-4xl font-bold leading-none text-sky-900">{naoLidas}</p>
+      <section className="grid gap-3 sm:grid-cols-2">
+        <article className="rounded-xl border border-sky-200 bg-sky-50 p-5 shadow-sm">
+          <p className="text-xs font-semibold uppercase tracking-wide text-sky-700">Nao lidas</p>
+          <p className="mt-2 text-4xl font-bold leading-none text-sky-900">{naoLidas}</p>
+        </article>
+        <article className="rounded-xl border border-zinc-200 bg-white p-5 shadow-sm">
+          <p className="text-xs font-semibold uppercase tracking-wide text-zinc-500">Lidas</p>
+          <p className="mt-2 text-4xl font-bold leading-none text-zinc-900">{totalLidas}</p>
+        </article>
       </section>
 
       {erro ? (
@@ -185,54 +238,143 @@ export default function ComunicacaoPage() {
         </section>
       ) : null}
 
-      {!erro && isLoadingNotificacoes ? (
+      {erroAcao ? (
+        <section className="rounded-xl border border-rose-200 bg-rose-50 p-5 shadow-sm">
+          <p className="text-sm font-medium text-rose-800">{erroAcao}</p>
+        </section>
+      ) : null}
+
+      {!erro && isLoadingNotificacoes && notificacoesOrdenadas.length === 0 ? (
         <section className="rounded-xl border border-zinc-200 bg-white p-5 shadow-sm">
           <p className="text-sm text-zinc-500">Carregando notificacoes...</p>
         </section>
       ) : null}
 
-      {!erro && !isLoadingNotificacoes && notificacoes.length === 0 ? (
+      {!erro && !isLoadingNotificacoes && notificacoesOrdenadas.length === 0 ? (
         <section className="rounded-xl border border-zinc-200 bg-white p-5 shadow-sm">
           <p className="text-sm text-zinc-600">Nenhuma notificacao encontrada.</p>
         </section>
       ) : null}
 
-      {!erro && !isLoadingNotificacoes && notificacoes.length > 0 ? (
-        <section className="overflow-x-auto rounded-xl border border-zinc-200 bg-white shadow-sm">
-          <table className="min-w-full divide-y divide-zinc-200 text-sm">
-            <thead className="bg-zinc-50 text-left text-xs font-semibold uppercase tracking-wide text-zinc-600">
-              <tr>
-                <th className="px-4 py-3">Titulo</th>
-                <th className="px-4 py-3">Status</th>
-                <th className="px-4 py-3">Data</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-zinc-100">
-              {notificacoes.map((notificacao, index) => (
-                <tr key={notificacao?.id || `${tituloNotificacao(notificacao, index)}-${index}`}>
-                  <td className="px-4 py-3 font-medium text-zinc-900">
-                    {tituloNotificacao(notificacao, index)}
-                  </td>
-                  <td className="whitespace-nowrap px-4 py-3">
-                    <span
-                      className={`rounded-full px-2 py-1 text-xs font-semibold ${
-                        notificacaoNaoLida(notificacao)
-                          ? 'bg-amber-100 text-amber-800'
-                          : 'bg-emerald-100 text-emerald-700'
-                      }`}
+      {!erro && notificacoesOrdenadas.length > 0 ? (
+        <section className="space-y-3">
+          {notificacoesOrdenadas.map((notificacao, index) => {
+            const naoLida = notificacaoNaoLida(notificacao);
+            const tipo = obterTipoNotificacao(notificacao);
+            const IconeTipo = tipo.icon;
+            const titulo = obterTitulo(notificacao, index);
+            const descricao = obterDescricao(notificacao);
+            const data = formatarDataHora(obterDataNotificacao(notificacao));
+            const aguardandoAtualizacao = idAtualizando === notificacao?.id;
+
+            return (
+              <article
+                key={notificacao?.id || `${titulo}-${index}`}
+                className={`rounded-xl border p-4 shadow-sm transition ${
+                  naoLida
+                    ? 'border-sky-200 bg-sky-50'
+                    : 'border-zinc-200 bg-white opacity-75'
+                }`}
+              >
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="min-w-0 space-y-2">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span
+                        className={`inline-flex items-center gap-1 rounded-full px-2 py-1 text-xs font-semibold ${tipo.classes}`}
+                      >
+                        <IconeTipo />
+                        {tipo.label}
+                      </span>
+
+                      <span
+                        className={`rounded-full px-2 py-1 text-xs font-semibold ${
+                          naoLida
+                            ? 'bg-amber-100 text-amber-800'
+                            : 'bg-emerald-100 text-emerald-700'
+                        }`}
+                      >
+                        {naoLida ? 'Nao lida' : 'Lida'}
+                      </span>
+
+                      <span className="text-xs text-zinc-500">{data}</span>
+                    </div>
+
+                    <p className="text-base font-semibold text-zinc-900">{titulo}</p>
+                    {descricao ? <p className="text-sm text-zinc-600">{descricao}</p> : null}
+                  </div>
+
+                  {naoLida ? (
+                    <button
+                      type="button"
+                      onClick={() => handleMarcarComoLida(notificacao?.id)}
+                      disabled={!notificacao?.id || aguardandoAtualizacao || isAtualizando}
+                      className="shrink-0 rounded-md border border-sky-300 bg-white px-3 py-2 text-sm font-medium text-sky-800 transition hover:bg-sky-50 disabled:cursor-not-allowed disabled:opacity-60"
                     >
-                      {notificacaoNaoLida(notificacao) ? 'Nao lida' : 'Lida'}
-                    </span>
-                  </td>
-                  <td className="whitespace-nowrap px-4 py-3 text-zinc-700">
-                    {formatarDataHora(dataNotificacao(notificacao))}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+                      {aguardandoAtualizacao ? 'Marcando...' : 'Marcar como lida'}
+                    </button>
+                  ) : null}
+                </div>
+              </article>
+            );
+          })}
         </section>
       ) : null}
     </main>
+  );
+}
+
+function IconeBase({ children }) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      className="h-3.5 w-3.5"
+    >
+      {children}
+    </svg>
+  );
+}
+
+function ObrigacaoIcon() {
+  return (
+    <IconeBase>
+      <path d="M7 3.5v3" />
+      <path d="M17 3.5v3" />
+      <rect x="4" y="6.5" width="16" height="14" rx="2" />
+      <path d="M4 10h16" />
+    </IconeBase>
+  );
+}
+
+function ProcessoIcon() {
+  return (
+    <IconeBase>
+      <rect x="3.5" y="5.5" width="17" height="13" rx="2" />
+      <path d="M8 10h8" />
+      <path d="M8 14h5" />
+    </IconeBase>
+  );
+}
+
+function ArquivoIcon() {
+  return (
+    <IconeBase>
+      <path d="M7 3.5h7l4 4V20.5H7z" />
+      <path d="M14 3.5v4h4" />
+      <path d="M9 12h6" />
+      <path d="M9 15.5h6" />
+    </IconeBase>
+  );
+}
+
+function GeralIcon() {
+  return (
+    <IconeBase>
+      <path d="M12 4.5a4.5 4.5 0 0 0-4.5 4.5v2.7L6 14v1h12v-1l-1.5-2.3V9A4.5 4.5 0 0 0 12 4.5Z" />
+      <path d="M9.5 17.5a2.5 2.5 0 0 0 5 0" />
+    </IconeBase>
   );
 }

--- a/frontend/src/app/layout.jsx
+++ b/frontend/src/app/layout.jsx
@@ -1,5 +1,7 @@
 import './globals.css';
 import { AuthProvider } from '../context/AuthContext';
+import { NotificacoesProvider } from '../context/NotificacoesContext';
+import AppShell from '../components/layout/AppShell';
 
 export const metadata = { title: 'Efficience Co' };
 
@@ -7,7 +9,11 @@ export default function RootLayout({ children }) {
   return (
     <html lang="pt-BR">
       <body className="min-h-screen antialiased">
-        <AuthProvider>{children}</AuthProvider>
+        <AuthProvider>
+          <NotificacoesProvider>
+            <AppShell>{children}</AppShell>
+          </NotificacoesProvider>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/frontend/src/components/dashboard/NotificacoesWidget.jsx
+++ b/frontend/src/components/dashboard/NotificacoesWidget.jsx
@@ -1,76 +1,10 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { listarNotificacoes } from '../../services/notificacoes.service';
+import { useMemo } from 'react';
+import { obterDataNotificacao, useNotificacoes } from '../../context/NotificacoesContext';
 import WidgetCard from './WidgetCard';
 
 const LIMITE_VISUAL = 4;
-
-function obterMensagemErro(error) {
-  return (
-    error?.response?.data?.erro ||
-    error?.response?.data?.message ||
-    error?.message ||
-    'Nao foi possivel carregar as notificacoes.'
-  );
-}
-
-function normalizarNotificacoes(payload) {
-  if (Array.isArray(payload)) {
-    return payload;
-  }
-
-  if (Array.isArray(payload?.data)) {
-    return payload.data;
-  }
-
-  if (Array.isArray(payload?.items)) {
-    return payload.items;
-  }
-
-  if (Array.isArray(payload?.notificacoes)) {
-    return payload.notificacoes;
-  }
-
-  return [];
-}
-
-function notificacaoNaoLida(notificacao) {
-  if (!notificacao) {
-    return false;
-  }
-
-  if (notificacao.nao_lida === true) {
-    return true;
-  }
-
-  if (notificacao.lida === false || notificacao.lido === false || notificacao.read === false) {
-    return true;
-  }
-
-  const status = String(notificacao.status || '').toLowerCase();
-  if (status === 'nao_lida' || status === 'nao lida' || status === 'unread') {
-    return true;
-  }
-
-  return false;
-}
-
-function contarNaoLidas(payload, notificacoes) {
-  if (typeof payload?.nao_lidas === 'number') {
-    return payload.nao_lidas;
-  }
-
-  if (typeof payload?.total_nao_lidas === 'number') {
-    return payload.total_nao_lidas;
-  }
-
-  if (typeof payload?.unread === 'number') {
-    return payload.unread;
-  }
-
-  return notificacoes.filter(notificacaoNaoLida).length;
-}
 
 function obterTitulo(notificacao, index) {
   return (
@@ -79,15 +13,6 @@ function obterTitulo(notificacao, index) {
     notificacao?.mensagem ||
     notificacao?.descricao ||
     `Notificacao ${index + 1}`
-  );
-}
-
-function obterData(notificacao) {
-  return (
-    notificacao?.criado_em ||
-    notificacao?.created_at ||
-    notificacao?.data ||
-    notificacao?.timestamp
   );
 }
 
@@ -108,33 +33,12 @@ function formatarDataHora(data) {
 }
 
 export default function NotificacoesWidget() {
-  const [payload, setPayload] = useState(null);
-  const [notificacoes, setNotificacoes] = useState([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [erro, setErro] = useState('');
+  const { notificacoes, naoLidas, isLoadingNotificacoes, erro, carregarNotificacoes } =
+    useNotificacoes();
 
-  const carregarNotificacoes = useCallback(async () => {
-    setIsLoading(true);
-    setErro('');
-
-    try {
-      const data = await listarNotificacoes();
-      setPayload(data);
-      setNotificacoes(normalizarNotificacoes(data));
-    } catch (error) {
-      setErro(obterMensagemErro(error));
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    carregarNotificacoes();
-  }, [carregarNotificacoes]);
-
-  const naoLidas = useMemo(
-    () => contarNaoLidas(payload, notificacoes),
-    [payload, notificacoes],
+  const listaResumida = useMemo(
+    () => notificacoes.slice(0, LIMITE_VISUAL),
+    [notificacoes],
   );
 
   return (
@@ -144,9 +48,9 @@ export default function NotificacoesWidget() {
       href="/comunicacao"
       linkLabel="Abrir comunicacao"
     >
-      {isLoading ? <p className="text-sm text-zinc-500">Carregando notificacoes...</p> : null}
+      {isLoadingNotificacoes ? <p className="text-sm text-zinc-500">Carregando notificacoes...</p> : null}
 
-      {!isLoading && erro ? (
+      {!isLoadingNotificacoes && erro ? (
         <div className="space-y-3 rounded-lg border border-rose-200 bg-rose-50 p-3">
           <p className="text-sm text-rose-800">{erro}</p>
           <button
@@ -159,7 +63,7 @@ export default function NotificacoesWidget() {
         </div>
       ) : null}
 
-      {!isLoading && !erro ? (
+      {!isLoadingNotificacoes && !erro ? (
         <div className="space-y-4">
           <div className="rounded-lg border border-sky-200 bg-sky-50 p-3">
             <p className="text-xs font-medium uppercase tracking-wide text-sky-700">
@@ -170,11 +74,11 @@ export default function NotificacoesWidget() {
             </p>
           </div>
 
-          {notificacoes.length > 0 ? (
+          {listaResumida.length > 0 ? (
             <ul className="space-y-2">
-              {notificacoes.slice(0, LIMITE_VISUAL).map((notificacao, index) => {
+              {listaResumida.map((notificacao, index) => {
                 const titulo = obterTitulo(notificacao, index);
-                const data = formatarDataHora(obterData(notificacao));
+                const data = formatarDataHora(obterDataNotificacao(notificacao));
 
                 return (
                   <li

--- a/frontend/src/components/layout/AppShell.jsx
+++ b/frontend/src/components/layout/AppShell.jsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { useAuth } from '../../context/AuthContext';
+import Sidebar from './Sidebar';
+
+function deveExibirSidebar(pathname, isAuthenticated) {
+  if (!isAuthenticated) {
+    return false;
+  }
+
+  if (!pathname) {
+    return false;
+  }
+
+  return pathname !== '/';
+}
+
+export default function AppShell({ children }) {
+  const pathname = usePathname();
+  const { isAuthenticated } = useAuth();
+  const exibirSidebar = deveExibirSidebar(pathname, isAuthenticated);
+
+  if (!exibirSidebar) {
+    return children;
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-100 md:flex">
+      <Sidebar />
+      <div className="min-w-0 flex-1 md:ml-64">{children}</div>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -1,3 +1,249 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useAuth } from '../../context/AuthContext';
+import { useNotificacoes } from '../../context/NotificacoesContext';
+
+const NAV_ITEMS = [
+  {
+    href: '/dashboard',
+    label: 'Dashboard',
+    icon: DashboardIcon,
+    exact: true,
+  },
+  {
+    href: '/dashboard/obrigacoes',
+    label: 'Obrigacoes',
+    icon: ObrigacoesIcon,
+  },
+  {
+    href: '/dashboard/processos',
+    label: 'Processos',
+    icon: ProcessosIcon,
+  },
+  {
+    href: '/dashboard/logs',
+    label: 'Logs',
+    icon: LogsIcon,
+  },
+  {
+    href: '/dashboard/regras',
+    label: 'Regras',
+    icon: RegrasIcon,
+  },
+  {
+    href: '/dashboard/usuarios',
+    label: 'Usuarios',
+    icon: UsuariosIcon,
+  },
+  {
+    href: '/comunicacao',
+    label: 'Comunicacao',
+    icon: NotificacoesIcon,
+    badge: true,
+  },
+  {
+    href: '/admin/clientes',
+    label: 'Admin Clientes',
+    icon: EmpresaIcon,
+  },
+];
+
+function isRouteActive(pathname, item) {
+  const { href, exact } = item;
+
+  if (!pathname) {
+    return false;
+  }
+
+  if (pathname === href) {
+    return true;
+  }
+
+  if (exact) {
+    return false;
+  }
+
+  return pathname.startsWith(`${href}/`);
+}
+
+function sidebarLinkClasses(ativo) {
+  if (ativo) {
+    return 'bg-sky-100 text-sky-900 ring-1 ring-sky-300';
+  }
+
+  return 'text-slate-700 hover:bg-slate-100 hover:text-slate-900';
+}
+
+function badgeClasses(total) {
+  if (total > 0) {
+    return 'bg-rose-600 text-white';
+  }
+
+  return 'bg-slate-200 text-slate-700';
+}
+
 export default function Sidebar() {
-  return <aside>Sidebar — a implementar</aside>;
+  const pathname = usePathname();
+  const { logout, user } = useAuth();
+  const { naoLidas } = useNotificacoes();
+
+  return (
+    <aside className="w-full border-b border-slate-200 bg-white md:fixed md:inset-y-0 md:w-64 md:border-b-0 md:border-r">
+      <div className="flex h-full flex-col">
+        <div className="border-b border-slate-200 px-5 py-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-sky-700">
+            Efficience Co
+          </p>
+          <p className="mt-1 text-lg font-semibold text-slate-900">Plataforma</p>
+          <p className="mt-2 truncate text-sm text-slate-500">
+            {user?.nome || user?.email || 'Usuario autenticado'}
+          </p>
+        </div>
+
+        <nav className="flex-1 overflow-y-auto px-3 py-4">
+          <ul className="grid gap-1">
+            {NAV_ITEMS.map((item) => {
+              const ativo = isRouteActive(pathname, item);
+              const Icon = item.icon;
+
+              return (
+                <li key={item.href}>
+                  <Link
+                    href={item.href}
+                    className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition ${sidebarLinkClasses(ativo)}`}
+                  >
+                    <Icon />
+                    <span className="flex-1">{item.label}</span>
+                    {item.badge ? (
+                      <span
+                        className={`min-w-6 rounded-full px-2 py-0.5 text-center text-xs font-semibold ${badgeClasses(
+                          naoLidas,
+                        )}`}
+                      >
+                        {naoLidas}
+                      </span>
+                    ) : null}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </nav>
+
+        <div className="border-t border-slate-200 px-4 py-4">
+          <button
+            type="button"
+            onClick={logout}
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-100"
+          >
+            Sair
+          </button>
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+function IconBase({ children }) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      className="h-4 w-4 shrink-0"
+    >
+      {children}
+    </svg>
+  );
+}
+
+function DashboardIcon() {
+  return (
+    <IconBase>
+      <rect x="3.5" y="3.5" width="7" height="7" rx="1.2" />
+      <rect x="13.5" y="3.5" width="7" height="5" rx="1.2" />
+      <rect x="13.5" y="11.5" width="7" height="9" rx="1.2" />
+      <rect x="3.5" y="13.5" width="7" height="7" rx="1.2" />
+    </IconBase>
+  );
+}
+
+function ObrigacoesIcon() {
+  return (
+    <IconBase>
+      <path d="M7 3.5v3" />
+      <path d="M17 3.5v3" />
+      <rect x="4" y="6.5" width="16" height="14" rx="2" />
+      <path d="M4 10h16" />
+    </IconBase>
+  );
+}
+
+function ProcessosIcon() {
+  return (
+    <IconBase>
+      <path d="M3.5 7.5h17" />
+      <rect x="3.5" y="4" width="17" height="16.5" rx="2" />
+      <path d="M8 12h8" />
+      <path d="M8 15.5h5" />
+    </IconBase>
+  );
+}
+
+function LogsIcon() {
+  return (
+    <IconBase>
+      <path d="M4 5.5h16" />
+      <path d="M4 12h16" />
+      <path d="M4 18.5h10" />
+    </IconBase>
+  );
+}
+
+function RegrasIcon() {
+  return (
+    <IconBase>
+      <circle cx="8" cy="8" r="2.2" />
+      <circle cx="16" cy="16" r="2.2" />
+      <path d="M9.7 9.7l4.6 4.6" />
+      <path d="M14.3 9.7l-4.6 4.6" />
+    </IconBase>
+  );
+}
+
+function UsuariosIcon() {
+  return (
+    <IconBase>
+      <circle cx="9" cy="9" r="3" />
+      <path d="M4.5 19c0-2.5 2-4.5 4.5-4.5S13.5 16.5 13.5 19" />
+      <circle cx="17.5" cy="9.5" r="2.2" />
+      <path d="M15.5 18.8c.3-2 1.9-3.6 3.9-3.9" />
+    </IconBase>
+  );
+}
+
+function NotificacoesIcon() {
+  return (
+    <IconBase>
+      <path d="M12 4.5a4.5 4.5 0 0 0-4.5 4.5v2.7L6 14v1h12v-1l-1.5-2.3V9A4.5 4.5 0 0 0 12 4.5Z" />
+      <path d="M9.5 17.5a2.5 2.5 0 0 0 5 0" />
+    </IconBase>
+  );
+}
+
+function EmpresaIcon() {
+  return (
+    <IconBase>
+      <rect x="4" y="3.5" width="16" height="17" rx="1.5" />
+      <path d="M8 7.5h2" />
+      <path d="M14 7.5h2" />
+      <path d="M8 11.5h2" />
+      <path d="M14 11.5h2" />
+      <path d="M8 15.5h8" />
+    </IconBase>
+  );
 }

--- a/frontend/src/context/NotificacoesContext.jsx
+++ b/frontend/src/context/NotificacoesContext.jsx
@@ -1,0 +1,227 @@
+'use client';
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { listar, marcarLida } from '../services/notificacoes.service';
+import { useAuth } from './AuthContext';
+
+const NotificacoesContext = createContext(null);
+
+function obterMensagemErro(error, fallback) {
+  return (
+    error?.response?.data?.erro ||
+    error?.response?.data?.message ||
+    error?.message ||
+    fallback
+  );
+}
+
+function normalizarNotificacoes(payload) {
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+
+  if (Array.isArray(payload?.data)) {
+    return payload.data;
+  }
+
+  if (Array.isArray(payload?.items)) {
+    return payload.items;
+  }
+
+  if (Array.isArray(payload?.notificacoes)) {
+    return payload.notificacoes;
+  }
+
+  return [];
+}
+
+export function obterDataNotificacao(notificacao) {
+  return (
+    notificacao?.criado_em ||
+    notificacao?.created_at ||
+    notificacao?.data ||
+    notificacao?.timestamp
+  );
+}
+
+function obterTimestamp(notificacao) {
+  const data = obterDataNotificacao(notificacao);
+  const valor = new Date(data || '');
+  if (Number.isNaN(valor.getTime())) {
+    return 0;
+  }
+
+  return valor.getTime();
+}
+
+function ordenarPorMaisRecente(notificacoes) {
+  return [...notificacoes].sort((a, b) => obterTimestamp(b) - obterTimestamp(a));
+}
+
+export function notificacaoNaoLida(notificacao) {
+  if (!notificacao) {
+    return false;
+  }
+
+  if (notificacao.nao_lida === true) {
+    return true;
+  }
+
+  if (notificacao.lida === false || notificacao.lido === false || notificacao.read === false) {
+    return true;
+  }
+
+  const status = String(notificacao.status || '').toLowerCase();
+  if (status === 'nao_lida' || status === 'nao lida' || status === 'unread') {
+    return true;
+  }
+
+  return false;
+}
+
+function marcarComoLidaLocal(notificacao) {
+  const statusNormalizado = String(notificacao?.status || '').toLowerCase();
+  const statusNaoLido =
+    statusNormalizado === 'nao_lida' ||
+    statusNormalizado === 'nao lida' ||
+    statusNormalizado === 'unread';
+
+  return {
+    ...notificacao,
+    nao_lida: false,
+    lida: true,
+    lido: true,
+    read: true,
+    status: statusNaoLido ? 'lida' : notificacao?.status,
+  };
+}
+
+export function NotificacoesProvider({ children }) {
+  const { isAuthenticated, isLoading } = useAuth();
+  const [notificacoes, setNotificacoes] = useState([]);
+  const [isLoadingNotificacoes, setIsLoadingNotificacoes] = useState(false);
+  const [erro, setErro] = useState('');
+  const [isAtualizando, setIsAtualizando] = useState(false);
+
+  const carregarNotificacoes = useCallback(async () => {
+    if (!isAuthenticated) {
+      return;
+    }
+
+    setIsLoadingNotificacoes(true);
+    setErro('');
+
+    try {
+      const payload = await listar();
+      setNotificacoes(ordenarPorMaisRecente(normalizarNotificacoes(payload)));
+    } catch (error) {
+      setErro(obterMensagemErro(error, 'Nao foi possivel carregar as notificacoes.'));
+    } finally {
+      setIsLoadingNotificacoes(false);
+    }
+  }, [isAuthenticated]);
+
+  useEffect(() => {
+    if (isLoading) {
+      return;
+    }
+
+    if (!isAuthenticated) {
+      setNotificacoes([]);
+      setErro('');
+      setIsLoadingNotificacoes(false);
+      setIsAtualizando(false);
+      return;
+    }
+
+    carregarNotificacoes();
+  }, [carregarNotificacoes, isAuthenticated, isLoading]);
+
+  const marcarComoLida = useCallback(async (id) => {
+    if (!id) {
+      return;
+    }
+
+    setIsAtualizando(true);
+
+    try {
+      await marcarLida(id);
+      setNotificacoes((currentValue) =>
+        currentValue.map((notificacao) =>
+          String(notificacao?.id) === String(id)
+            ? marcarComoLidaLocal(notificacao)
+            : notificacao,
+        ),
+      );
+    } finally {
+      setIsAtualizando(false);
+    }
+  }, []);
+
+  const marcarTodasComoLidas = useCallback(async () => {
+    const pendentes = notificacoes.filter(notificacaoNaoLida);
+    if (pendentes.length === 0) {
+      return;
+    }
+
+    setIsAtualizando(true);
+
+    try {
+      await Promise.all(
+        pendentes.map((notificacao) =>
+          notificacao?.id ? marcarLida(notificacao.id) : Promise.resolve(),
+        ),
+      );
+
+      setNotificacoes((currentValue) =>
+        currentValue.map((notificacao) =>
+          notificacaoNaoLida(notificacao)
+            ? marcarComoLidaLocal(notificacao)
+            : notificacao,
+        ),
+      );
+    } finally {
+      setIsAtualizando(false);
+    }
+  }, [notificacoes]);
+
+  const naoLidas = useMemo(
+    () => notificacoes.filter(notificacaoNaoLida).length,
+    [notificacoes],
+  );
+
+  const value = useMemo(
+    () => ({
+      notificacoes,
+      naoLidas,
+      isLoadingNotificacoes,
+      erro,
+      isAtualizando,
+      carregarNotificacoes,
+      marcarComoLida,
+      marcarTodasComoLidas,
+    }),
+    [
+      notificacoes,
+      naoLidas,
+      isLoadingNotificacoes,
+      erro,
+      isAtualizando,
+      carregarNotificacoes,
+      marcarComoLida,
+      marcarTodasComoLidas,
+    ],
+  );
+
+  return <NotificacoesContext.Provider value={value}>{children}</NotificacoesContext.Provider>;
+}
+
+export function useNotificacoes() {
+  const context = useContext(NotificacoesContext);
+
+  if (!context) {
+    throw new Error('useNotificacoes precisa ser usado dentro de NotificacoesProvider.');
+  }
+
+  return context;
+}

--- a/frontend/src/services/notificacoes.service.js
+++ b/frontend/src/services/notificacoes.service.js
@@ -1,6 +1,6 @@
 import api from './api';
 
-export async function listarNotificacoes({ limit, offset } = {}) {
+export async function listar({ limit, offset } = {}) {
   const response = await api.get('/notificacoes', {
     params: {
       ...(typeof limit === 'number' ? { limit } : {}),
@@ -10,3 +10,14 @@ export async function listarNotificacoes({ limit, offset } = {}) {
 
   return response.data;
 }
+
+export async function marcarLida(id) {
+  if (!id) {
+    throw new Error('Id da notificacao e obrigatorio para marcar como lida.');
+  }
+
+  const response = await api.patch(`/notificacoes/${id}/lida`);
+  return response.data;
+}
+
+export const listarNotificacoes = listar;


### PR DESCRIPTION
Página de comunicação virou central de notificações com:
ordenação por mais recentes,
ícone por tipo (obrigacao, processo, arquivo),
distinção visual de lidas vs não lidas,
ação Marcar como lida,
ação Marcar todas como lidas.
Badge no sidebar agora mostra total de não lidas em tempo real (sem refresh).
Após Marcar todas como lidas, o badge vai para 0.
Serviço atualizado com os métodos pedidos:
listar()
marcarLida(id)